### PR TITLE
Envíos de correos cuando se asiga una CAtCon a un comentario

### DIFF
--- a/app/controllers/comentarios_controller.rb
+++ b/app/controllers/comentarios_controller.rb
@@ -245,6 +245,7 @@ class ComentariosController < ApplicationController
   # PATCH/PUT /comentarios/1
   # PATCH/PUT /comentarios/1.json
   def update
+    ya_estaba_resuelto = Comentario::RESUELTOS.include?(@comentario.estatus) #Ya estaba en algun estatus de resuleto?
     if params[:estatus].present?
       @comentario.estatus = params[:estatus]
       @comentario.usuario_id2 = current_usuario.id
@@ -255,8 +256,9 @@ class ComentariosController < ApplicationController
 
     if @comentario.changed? && @comentario.save
       if Comentario::RESUELTOS.include?(@comentario.estatus)
-        EnviaCorreo.comentario_resuelto(@comentario).deliver
+        EnviaCorreo.comentario_resuelto(@comentario).deliver unless ya_estaba_resuelto #Solo envia correo cuando cambia el estatus
       end
+      EnviaCorreo.avisar_responsable_contenido(@comentario, CategoriasContenido.find(params[:categorias_contenido_id]).usuarios.map(&:email)) if params[:categorias_contenido_id].present?
 
       render json: {estatus: 1}.to_json
     else

--- a/app/controllers/comentarios_controller.rb
+++ b/app/controllers/comentarios_controller.rb
@@ -258,8 +258,13 @@ class ComentariosController < ApplicationController
       if Comentario::RESUELTOS.include?(@comentario.estatus)
         EnviaCorreo.comentario_resuelto(@comentario).deliver unless ya_estaba_resuelto #Solo envia correo cuando cambia el estatus
       end
-      EnviaCorreo.avisar_responsable_contenido(@comentario, CategoriasContenido.find(params[:categorias_contenido_id]).usuarios.map(&:email)) if params[:categorias_contenido_id].present?
-
+      if params[:categorias_contenido_id].present?
+        #TODO aqui primero (y tamién debe ir algo muy similar en el create), se debe de preguntar primero por la categoria_contenido (usuarios), y despues por la taxonomia _especifica(i.e. si los usuarios q me regreso la consulta anterior cumplen con la condicion de taxa del comentario):
+        #CategoriasContenido.find(params[:categorias_contenido_id]).usuarios # dame todos los usuarios de esta categoría (array)
+        #Conservar en el array si el usuario NO esta en la relacion usuarios_especie o Sí está y su taxa_especfica pertenece a lo ancestros(o es ella misma) del comentario.especie_id
+        #si se cumple entonces a los q quedaron, a esos hazles el map(&:email) y pasaselos al EnviaCorreo.avisar_responsable_contenido
+        EnviaCorreo.avisar_responsable_contenido(@comentario, CategoriasContenido.find(params[:categorias_contenido_id]).usuarios.map(&:email)).deliver
+      end
       render json: {estatus: 1}.to_json
     else
       render json: {estatus: 0}.to_json

--- a/app/mailers/envia_correo.rb
+++ b/app/mailers/envia_correo.rb
@@ -37,6 +37,10 @@ class EnviaCorreo < Devise::Mailer
     mail(:to => correo, :subject => 'EncicloVida: Descargar taxa')# if Rails.env.production?
   end
 
+  def avisar_responsable_contenido(comentario,correos)
+    completa_datos_comentario(comentario)
+    mail(:to => correos.join(','), :subject => 'EncicloVida: Te ha sido asignado un comentario para solucionar') if (Rails.env.production? || correos.join(',').include?("ggonzalez") || correos.join(',').include?("calonso") || correos.join(',').include?("albertoglezba") || correos.join(',').include?("mailinator"))
+  end
 
   private
 

--- a/app/views/envia_correo/avisar_responsable_contenido.html.erb
+++ b/app/views/envia_correo/avisar_responsable_contenido.html.erb
@@ -1,0 +1,21 @@
+<p>
+  Se te ha asignado el siguiente comentario:
+  <% con_taxon = @nombre_cientifico.present? %>
+  <span style="font-size: 1.2em;">
+  <% if con_taxon %>
+      <% if @nombre_comun.present? %>
+          <%= @nombre_comun %> (<strong><%= @nombre_cientifico %></strong>)
+      <% else %>
+          <strong><%= @nombre_cientifico %></strong>
+      <% end %>
+  <% end %>
+  </span>
+</p>
+
+<blockquote style="font-style: italic;">
+  <%= @comentario.comentario %>
+</blockquote>
+
+<p>
+  Para poder contestarlo, ingresa al <%= link_to 'panel de administracion de comentarios', admin_path %>.
+</p>


### PR DESCRIPTION
-Tambien se arreglo el bug de multiples envios
-Falta replicarlo en el create y hacerlo para la taxa especifica (however deje comentarios (#TODO) muy puntual)