### PR TITLE
Bug de Diana hernandez en los comentarios

### DIFF
--- a/app/assets/javascripts/scrolling_basico.js
+++ b/app/assets/javascripts/scrolling_basico.js
@@ -70,7 +70,7 @@
 				$(window).scroll(function() {
 					
 					// Check the user is at the bottom of the element
-                    if($(window).scrollTop() + $(window).height() == $(document).height() && !settings.busy) {
+                    if(Math.ceil($(window).scrollTop()) + $(window).height() == $(document).height() && !settings.busy) {
 						
 						// Now we are working, so busy is true
 						busy = true;


### PR DESCRIPTION
Puede ser q el tamaño de la ventana devuelva flotante, entonces solicitamos el entero siguiente para q la condicional se cumpla y active el scrolling, sucede cuando hay zoom (en los comentarios)